### PR TITLE
Update peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const greet = zodCommand({
     name: z.string().describe('Name of the person to greet'),
   },
   opts: {
-    excited: z.boolean().default(false).describe('e;Add an exclamation mark'), // 'e;' makes -e an alias
+    excited: z.boolean().prefault(false).describe('e;Add an exclamation mark'), // 'e;' makes -e an alias
   },
   async action({ name }, { excited }) {
     console.log(`Hello, ${name}${excited ? '!' : '.'}`)
@@ -48,17 +48,15 @@ program
 - **Aliases for options**: If you start a description with a letter and a semicolon (e.g. `"f;The file to export to"`), that letter will be used as a short alias (e.g. `-f`).
 - **Perfect help output**: The generated help text is clear and complete—try running your command with `--help` to see for yourself!
 
-### Zod 4 support
+> [!NOTE]
+> When using zod `v4`, you will usually want to use [`.prefault()`](https://zod.dev/v4/changelog#default-updates) instead of `.default()`.
 
-Currently, the package uses zod `v3` by default. Zod version can be specified by importing the appropriate version from the `zod3` or `zod4` submodules.
+### Zod 3 support
+
+The package uses zod `v4` by default. Zod version can be specified by importing the appropriate version from the `zod3` or `zod4` submodules.
 
 ```ts
-import { zodCommand } from 'zod-commander/zod4'
+import { zodCommand } from 'zod-commander/zod4' // equivalent to `import { zodCommand } from 'zod-commander'`
 // or
-import { zodCommand } from 'zod-commander/zod3' // equivalent to `import { zodCommand } from 'zod-commander'`
+import { zodCommand } from 'zod-commander/zod3'
 ```
-
-In the future, the default version will be changed to zod `v4`.
-
-> [!NOTE]
-> To use `zod-commander/zod4` in the same way as `zod-commander/zod3`, you should use [`.prefault()`](https://zod.dev/v4/changelog#default-updates) instead of `.default()`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ program
 - **Type-safe arguments and options**: Use zod schemas to define and validate CLI inputs.
 - **Booleans are treated as flags**: Any boolean option automatically becomes a CLI flag (e.g. `--excited`).
 - **Descriptive help**: `.describe()` on schemas provides help text for each argument/option.
-- **Default values**: Use `.default()` on zod schemas for default option values.
+- **Default values**: Use `.prefault()` (`.default()` for zod `v3`) on zod schemas for default option values.
 - **Async actions**: The `action` function can be async and receives parsed args and opts.
 - **No boilerplate**: Just export your command; integrate with your CLI runner as needed.
 - **Aliases for options**: If you start a description with a letter and a semicolon (e.g. `"f;The file to export to"`), that letter will be used as a short alias (e.g. `-f`).

--- a/jsr.json
+++ b/jsr.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://jsr.io/schema/config-file.v1.json",
 	"name": "@roman910dev/zod-commander",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"exports": {
 		".": "./src/zod3/index.ts",
 		"./zod3": "./src/zod3/index.ts",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"access": "public"
 	},
 	"peerDependencies": {
-		"commander": ">=8 <15",
+		"commander": ">=8 <16",
 		"zod": ">=3.20.0 <5"
 	},
 	"type": "module"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/zod3/index.d.mts",
-			"import": "./dist/zod3/index.mjs",
-			"require": "./dist/zod3/index.cjs",
-			"default": "./dist/zod3/index.mjs"
+			"types": "./dist/zod4/index.d.mts",
+			"import": "./dist/zod4/index.mjs",
+			"require": "./dist/zod4/index.cjs",
+			"default": "./dist/zod4/index.mjs"
 		},
 		"./zod3": {
 			"types": "./dist/zod3/index.d.mts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zod-commander",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"description": "A TypeScript utility for building type-safe CLI commands using commander and zod.",
 	"author": "Román Via-Dufresne Saus <roman910dev@gmail.com>(https://github.com/roman910dev)",
 	"license": "MIT",


### PR DESCRIPTION
### Breaking changes

- Use `zod4` version by default. If you are still using Zod `v3`, import from` zod-commander/zod3`.

### Added

- Enabled support for Commander `v15`.